### PR TITLE
Add Trino experimental SPIs usage checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 Collection of [Error Prone](https://github.com/google/error-prone) plugins that enhance the
 possibilities of Core Error Prone checks and can check for less-generic bug patterns that
 cannot be included in the core set of bug checkers.
+
+## Bug Checkers
+
+* [Check for usages of Trino experimental SPIs](trino-experimental-check/README.md)

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
 
         <project.build.targetJdk>17</project.build.targetJdk>
 
+        <dep.error-prone.version>2.15.0</dep.error-prone.version>
+        <dep.compile-testing.version>0.19</dep.compile-testing.version>
+
         <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
 
         <!-- Publish artifacts to our internal Maven repository -->
@@ -47,7 +50,107 @@
         <air.repository.release.url>https://starburstdata-sep-cicd-843985043183.d.codeartifact.us-east-2.amazonaws.com/maven/releases/</air.repository.release.url>
     </properties>
 
+    <modules>
+        <module>trino-experimental-check</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_check_api</artifactId>
+                <version>${dep.error-prone.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotation</artifactId>
+                <version>${dep.error-prone.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>${dep.error-prone.version}</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${dep.guava.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <!-- this empty dependency is a hack and not needed -->
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>listenablefuture</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.google.testing.compile</groupId>
+                <artifactId>compile-testing</artifactId>
+                <version>${dep.compile-testing.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_test_helpers</artifactId>
+                <version>${dep.error-prone.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.truth</groupId>
+                        <artifactId>truth</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.auto.value</groupId>
+                        <artifactId>auto-value</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/java</directory>
+                <includes>
+                    <include>**/testdata/**</include>
+                </includes>
+            </testResource>
+        </testResources>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -81,6 +184,9 @@
                                 <version>${dep.error-prone.version}</version>
                             </path>
                         </annotationProcessorPaths>
+                        <testExcludes>
+                            <exclude>**/testdata/**</exclude>
+                        </testExcludes>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -99,6 +205,25 @@
                             --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
                             --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
                         </argLine>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <additionalJOptions>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</additionalJOption>
+                        </additionalJOptions>
                     </configuration>
                 </plugin>
             </plugins>

--- a/trino-experimental-check/README.md
+++ b/trino-experimental-check/README.md
@@ -1,0 +1,37 @@
+# Trino Experimental SPI Usage Checker
+
+Bug checker for detecting usages of Trino SPIs that are annotated with the `@Experimental` 
+annotation. Such SPIs should be avoided in libraries and shared components that other 
+projects depend on. This checker is intended to be used by such libraries and shared 
+components to ensure that they don't use them.
+
+## Usage
+
+To use the checker configure your project to build with the Error Prone Java compiler and add
+`trino-experimental-check` annotation processor.
+
+Default severity for the diagnostics reported by this checker is warning. To customize that pass
+an additional compiler argument: `-Xep:UsingTrinoExperimentalSpi:ERROR`. Allowed values are: 
+`ERROR`, `WARNING`, `SUGGESTION`, `OFF`.
+
+### Maven
+
+In `pom.xml`:
+
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <configuration>
+        ...
+        <annotationProcessorPaths>
+            ...
+            <path>
+                <groupId>com.starburstdata.errorprone</groupId>
+                <artifactId>trino-experimental-check</artifactId>
+                <version>1.0</version>
+            </path>
+        </annotationProcessorPaths>
+    </configuration>
+</plugin>
+```

--- a/trino-experimental-check/pom.xml
+++ b/trino-experimental-check/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.starburstdata.errorprone</groupId>
+        <artifactId>error-prone-check-root</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>trino-experimental-check</artifactId>
+
+    <description>Disallow using Trino SPI that is marked as experimental</description>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_check_api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.testing.compile</groupId>
+            <artifactId>compile-testing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_test_helpers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/trino-experimental-check/src/main/java/com/starburstdata/errorprone/check/trinoexperimentalspi/AnnotatedApiUsageChecker.java
+++ b/trino-experimental-check/src/main/java/com/starburstdata/errorprone/check/trinoexperimentalspi/AnnotatedApiUsageChecker.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package com.starburstdata.errorprone.check.trinoexperimentalspi;
+
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.IdentifierTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.MemberReferenceTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.MemberSelectTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.ImportTree;
+import com.sun.source.tree.MemberReferenceTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Symbol;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Name;
+
+import java.util.Set;
+
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static javax.lang.model.element.ElementKind.ANNOTATION_TYPE;
+import static javax.lang.model.element.ElementKind.CLASS;
+import static javax.lang.model.element.ElementKind.CONSTRUCTOR;
+import static javax.lang.model.element.ElementKind.ENUM;
+import static javax.lang.model.element.ElementKind.ENUM_CONSTANT;
+import static javax.lang.model.element.ElementKind.FIELD;
+import static javax.lang.model.element.ElementKind.INTERFACE;
+import static javax.lang.model.element.ElementKind.METHOD;
+
+/**
+ * Abstract check for usages of APIs that are annotated with a specific annotation.
+ *
+ * <p>Notice: this checker won't produce a match for {@code super()} calls from classes subclassing a non-annotated class
+ * that has an annotated no-args constructor.</p>
+ *
+ * <p>Adapted from <a href="https://github.com/google/guava-beta-checker/blob/9b26aa980be7f70631921fd6695013547728eb1e/src/main/java/com/google/common/annotations/checkers/AnnotatedApiUsageChecker.java"
+ * >AnnotatedApiUsageChecker</a></p>
+ */
+public class AnnotatedApiUsageChecker
+        extends BugChecker
+        implements MemberSelectTreeMatcher, IdentifierTreeMatcher, MemberReferenceTreeMatcher
+{
+    /**
+     * Kinds of elements that should be considered annotated if the element's owner (i.e. the class
+     * it's declared in) is annotated. This is used to prevent things like type parameters that happen
+     * to be declared in an annotated class from being flagged.
+     */
+    private static final Set<ElementKind> INHERITS_ANNOTATION_FROM_OWNER = Set.of(
+            FIELD, METHOD, CONSTRUCTOR, ENUM_CONSTANT, CLASS, INTERFACE, ENUM, ANNOTATION_TYPE);
+
+    private final String basePackage;
+    private final String basePackagePrefix;
+
+    protected final String annotationType;
+
+    protected AnnotatedApiUsageChecker(String basePackage, String annotationType)
+    {
+        this.basePackage = basePackage;
+        this.basePackagePrefix = basePackage + ".";
+        this.annotationType = annotationType;
+    }
+
+    @Override
+    public final Description matchMemberSelect(MemberSelectTree tree, VisitorState state)
+    {
+        if (ASTHelpers.findEnclosingNode(state.getPath(), ImportTree.class) != null) {
+            return NO_MATCH;
+        }
+        return matchTree(tree);
+    }
+
+    @Override
+    public final Description matchIdentifier(IdentifierTree tree, VisitorState state)
+    {
+        return isSuperCall(tree) ? NO_MATCH : matchTree(tree);
+    }
+
+    @Override
+    public final Description matchMemberReference(MemberReferenceTree tree, VisitorState state)
+    {
+        return matchTree(tree);
+    }
+
+    private Description matchTree(Tree tree)
+    {
+        Symbol symbol = ASTHelpers.getSymbol(tree);
+        if (symbol != null && isInMatchingPackage(symbol) && isAnnotatedApi(symbol)) {
+            return describeMatch(tree);
+        }
+        return NO_MATCH;
+    }
+
+    private static boolean isSuperCall(IdentifierTree tree)
+    {
+        return tree.getName().contentEquals("super");
+    }
+
+    private boolean isInMatchingPackage(Symbol symbol)
+    {
+        String packageName = symbol.packge().fullname.toString();
+        return !isIgnoredPackage(packageName) &&
+                (packageName.equals(basePackage) || packageName.startsWith(basePackagePrefix));
+    }
+
+    /**
+     * May be overridden to ignore APIs under specific packages. Returns false by default.
+     */
+    protected boolean isIgnoredPackage(String packageName)
+    {
+        return false;
+    }
+
+    /**
+     * May be overridden to ignore specific types and their members. Returns false by default.
+     */
+    protected boolean isIgnoredType(String fullyQualifiedTypeName)
+    {
+        return false;
+    }
+
+    /**
+     * Returns true if the given symbol is annotated with the annotation or if it's a member of a type
+     * annotated with the annotation.
+     */
+    private boolean isAnnotatedApi(Symbol symbol)
+    {
+        Name name = symbol.getQualifiedName();
+        if (name != null && isIgnoredType(name.toString())) {
+            return false;
+        }
+
+        for (AnnotationMirror annotation : symbol.getAnnotationMirrors()) {
+            if (annotation.getAnnotationType().toString().equals(annotationType)) {
+                return true;
+            }
+        }
+
+        return isMemberOfAnnotatedApi(symbol);
+    }
+
+    private boolean isMemberOfAnnotatedApi(Symbol symbol)
+    {
+        return symbol != null
+                && INHERITS_ANNOTATION_FROM_OWNER.contains(symbol.getKind())
+                && isAnnotatedApi(symbol.owner);
+    }
+}

--- a/trino-experimental-check/src/main/java/com/starburstdata/errorprone/check/trinoexperimentalspi/UsingTrinoExperimentalSpiChecker.java
+++ b/trino-experimental-check/src/main/java/com/starburstdata/errorprone/check/trinoexperimentalspi/UsingTrinoExperimentalSpiChecker.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package com.starburstdata.errorprone.check.trinoexperimentalspi;
+
+import com.google.errorprone.BugPattern;
+
+@BugPattern(
+        name = "UsingTrinoExperimentalSpi",
+        summary = "Do not use Trino experimental SPI.",
+        explanation = """
+                Using Trino SPIs marked as experimental should be avoided \
+                in libraries and shared components that other projects depend on.""",
+        linkType = BugPattern.LinkType.NONE,
+        severity = BugPattern.SeverityLevel.WARNING)
+public final class UsingTrinoExperimentalSpiChecker
+        extends AnnotatedApiUsageChecker
+{
+    public UsingTrinoExperimentalSpiChecker()
+    {
+        super("io.trino.spi", "io.trino.spi.Experimental");
+    }
+}

--- a/trino-experimental-check/src/main/resources/META-INF/services/com.google.errorprone.bugpatterns.BugChecker
+++ b/trino-experimental-check/src/main/resources/META-INF/services/com.google.errorprone.bugpatterns.BugChecker
@@ -1,0 +1,1 @@
+com.starburstdata.errorprone.check.trinoexperimentalspi.UsingTrinoExperimentalSpiChecker

--- a/trino-experimental-check/src/test/java/com/starburstdata/errorprone/check/trinoexperimentalspi/TestUsingTrinoExperimentalSpiChecker.java
+++ b/trino-experimental-check/src/test/java/com/starburstdata/errorprone/check/trinoexperimentalspi/TestUsingTrinoExperimentalSpiChecker.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package com.starburstdata.errorprone.check.trinoexperimentalspi;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.testng.annotations.Test;
+
+@Test
+public class TestUsingTrinoExperimentalSpiChecker
+{
+    @Test
+    public void usingExperimentalSpiPositiveCases()
+    {
+        CompilationTestHelper compilationTestHelper = CompilationTestHelper.newInstance(UsingTrinoExperimentalSpiChecker.class, getClass());
+        compilationTestHelper.addSourceFile("UsingTrinoExperimentalSpiPositiveCases.java").doTest();
+    }
+
+    @Test
+    public void usingExperimentalSpiNegativeCases()
+    {
+        CompilationTestHelper compilationTestHelper = CompilationTestHelper.newInstance(UsingTrinoExperimentalSpiChecker.class, getClass());
+        compilationTestHelper.addSourceFile("UsingTrinoExperimentalSpiNegativeCases.java").doTest();
+    }
+}

--- a/trino-experimental-check/src/test/java/com/starburstdata/errorprone/check/trinoexperimentalspi/testdata/UsingTrinoExperimentalSpiNegativeCases.java
+++ b/trino-experimental-check/src/test/java/com/starburstdata/errorprone/check/trinoexperimentalspi/testdata/UsingTrinoExperimentalSpiNegativeCases.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package com.starburstdata.errorprone.check.trinoexperimentalspi.testdata;
+
+import io.trino.spi.trinoexperimentalspi.ClassWithAnnotatedMember;
+import io.trino.spi.trinoexperimentalspi.NotAnnotatedClass;
+
+import java.util.List;
+
+public class UsingTrinoExperimentalSpiNegativeCases
+{
+    private final Object instantiationOfNotAnnotatedClas = new NotAnnotatedClass();
+
+    private NotAnnotatedClass notAnnotatedClassAsField;
+
+    private final ClassWithAnnotatedMember classWithAnnotatedMember = new ClassWithAnnotatedMember();
+
+    private NotAnnotatedClass notAnnotatedApiAsInstanceVariable;
+
+    public void notAnnotatedApiAsParameter(NotAnnotatedClass param)
+    {}
+
+    public void notAnnotatedApiAsTypeParameter(List<NotAnnotatedClass> param)
+    {}
+
+    public void notAnnotatedApiAsLocalVariable()
+    {
+        NotAnnotatedClass var;
+    }
+
+    public void notAnnotatedApiAsMember()
+    {
+        classWithAnnotatedMember.notAnnotated();
+    }
+
+    public NotAnnotatedClass notAnnotatedClassAsReturnType()
+    {
+        return null;
+    }
+
+    public static class ExtendingNotAnnotatedApi
+            extends NotAnnotatedClass
+    {}
+}

--- a/trino-experimental-check/src/test/java/com/starburstdata/errorprone/check/trinoexperimentalspi/testdata/UsingTrinoExperimentalSpiPositiveCases.java
+++ b/trino-experimental-check/src/test/java/com/starburstdata/errorprone/check/trinoexperimentalspi/testdata/UsingTrinoExperimentalSpiPositiveCases.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package com.starburstdata.errorprone.check.trinoexperimentalspi.testdata;
+
+import io.trino.spi.trinoexperimentalspi.AnnotatedClass;
+import io.trino.spi.trinoexperimentalspi.ClassWithAnnotatedMember;
+
+import java.util.List;
+
+public class UsingTrinoExperimentalSpiPositiveCases
+{
+    // BUG: Diagnostic contains: Do not use Trino experimental SPI.
+    private final Object instantiationOfAnnotatedClass = new AnnotatedClass();
+
+    // BUG: Diagnostic contains: Do not use Trino experimental SPI.
+    private AnnotatedClass annotatedClassAsField;
+
+    private final ClassWithAnnotatedMember classWithAnnotatedMember = new ClassWithAnnotatedMember();
+
+    // BUG: Diagnostic contains: Do not use Trino experimental SPI.
+    private AnnotatedClass annotatedApiAsInstanceVariable;
+
+    // BUG: Diagnostic contains: Do not use Trino experimental SPI.
+    public void annotatedApiAsParameter(AnnotatedClass param)
+    {}
+
+    // BUG: Diagnostic contains: Do not use Trino experimental SPI.
+    public void annotatedApiAsTypeArgument(List<AnnotatedClass> param)
+    {}
+
+    public void annotatedApiAsLocalVariable()
+    {
+        // BUG: Diagnostic contains: Do not use Trino experimental SPI.
+        AnnotatedClass var;
+    }
+
+    public void annotatedApiAsMember()
+    {
+        // BUG: Diagnostic contains: Do not use Trino experimental SPI.
+        classWithAnnotatedMember.annotated();
+    }
+
+    // BUG: Diagnostic contains: Do not use Trino experimental SPI.
+    public AnnotatedClass annotatedClassAsReturnType()
+    {
+        return null;
+    }
+
+    public static class ExtendingAnnotatedApi
+            // BUG: Diagnostic contains: Do not use Trino experimental SPI.
+            extends AnnotatedClass
+    {}
+}

--- a/trino-experimental-check/src/test/java/io/trino/spi/Experimental.java
+++ b/trino-experimental-check/src/test/java/io/trino/spi/Experimental.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package io.trino.spi;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({TYPE, FIELD, METHOD, CONSTRUCTOR})
+public @interface Experimental
+{
+}

--- a/trino-experimental-check/src/test/java/io/trino/spi/trinoexperimentalspi/AnnotatedClass.java
+++ b/trino-experimental-check/src/test/java/io/trino/spi/trinoexperimentalspi/AnnotatedClass.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package io.trino.spi.trinoexperimentalspi;
+
+import io.trino.spi.Experimental;
+
+@Experimental
+public class AnnotatedClass
+{
+    public void foo()
+    {}
+}

--- a/trino-experimental-check/src/test/java/io/trino/spi/trinoexperimentalspi/ClassWithAnnotatedMember.java
+++ b/trino-experimental-check/src/test/java/io/trino/spi/trinoexperimentalspi/ClassWithAnnotatedMember.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package io.trino.spi.trinoexperimentalspi;
+
+import io.trino.spi.Experimental;
+
+public class ClassWithAnnotatedMember
+{
+    @Experimental
+    public void annotated()
+    {}
+
+    public void notAnnotated()
+    {}
+}

--- a/trino-experimental-check/src/test/java/io/trino/spi/trinoexperimentalspi/NotAnnotatedClass.java
+++ b/trino-experimental-check/src/test/java/io/trino/spi/trinoexperimentalspi/NotAnnotatedClass.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package io.trino.spi.trinoexperimentalspi;
+
+public class NotAnnotatedClass
+{
+    public void foo()
+    {}
+}


### PR DESCRIPTION
Bug checker for detecting usages of Trino SPIs that are annotated with the `@Experimental` annotation. Such SPIs should be avoided in libraries and shared components that other projects depend on. This checker is intended to be used by such libraries and shared components to ensure that they don't use them.