### PR TITLE
Add RequireNonNullMessageChecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ extensions.
 Both checkers can be fine-tuned with the following flags:
 
 * `-XepOpt:<CheckerName>:BasePackages=io.trino.spi,...` - check for usage of APIs from these base
-* packages only.
+  packages only.
 * `-XepOpt:<CheckerName>:IgnoredPackages=io.trino.spi,...` - ignore usage of APIs from these
-* packages
+  packages
 * `-XepOpt:<CheckerName>:IgnoredTypes=io.trino.spi.MyClass,...` - ignore usage of APIs from these
-* classes
+  classes
 
 Individual warnings can be suppressed with the `@SuppressWarnings("<CheckerName>")` annotation. For
 the `DeprecatedApi` checker, `@SuppressWarnings({"deprecation", "DeprecatedApi"})` suppresses both

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ extensions.
 
 ## Bug Checkers
 
+### Checkers for annotation-related issues
+
 * `DeprecatedApi` - Check for usages of `@Deprecated` APIs.
 * `TrinoExperimentalSpi` - Check for usages of Trino `@Experimental` SPIs.
 
@@ -18,12 +20,63 @@ Both checkers can be fine-tuned with the following flags:
 * `-XepOpt:<CheckerName>:IgnoredTypes=io.trino.spi.MyClass,...` - ignore usage of APIs from these
   classes
 
+### Checker for issues with `Objects::requireNonNull`
+
+* `RequireNonNullMessage` - Make sure that the message passed as the second argument is not
+  malformed
+
+This check focuses on cases of simple typos or mismatches of the error message with the thing being
+checked. It looks for calls to `Objects#requireNonNull` with a message which is a literal string
+matching the pattern:
+
+```
+<identifier>[additional information]["is null"][more additional information]
+```
+
+The "is null" part can also be one of some other variants, like "is required", "are missing",
+"can't be null" etc.
+
+There are two places where some additional information can be placed:
+
+* After the identifier:
+
+```
+<identifier> for something is null
+```
+
+* After the "is null" pattern:
+
+```
+<identifier> is null: this is bad
+```
+
+Or it can be both. Note that the "is null" part is also optional, so things like
+`requireNonNull(parameter, "parameter")` are also allowed.
+
+If a message matching the above pattern is found, it then checks if the `<identifier>` is identical
+to the identifier passed as the first argument to `requireNonNull` and will trigger if they're
+not. It will ignore anything more complex than a plain identifier. It will also ignore invocations
+with no message at all (these are meant to be quick sanity checks and are harmless) and where the
+message is not a literal string (e.g. concatenations, calls to `String#format` or lambdas, which
+are all considered custom messages not to be messed with).
+
+Outside constructors, though, the checks are slightly relaxed. The rationale for this is that in
+constructors `requireNonNull` is used primarily to sanity check the parameters and (usually) assign
+them to respective fields, so there's a lot of regularity which can be exploited for checking
+correctness. Outside of constructors, though, these calls are much more free-form and used for more
+purposes. Thus, the check will not report cases where the message can't be recognized as an
+"X is null" pattern, or if the part before that pattern is not an identifier. So, the following
+cases are not allowed in constructors, but are allowed otherwise:
+
+* `requireNonNull(parameter, "The information we require is null")`:
+* `requireNonNull(parameter, "I don't like this parameter")`:
+
+## Usage
+
 Individual warnings can be suppressed with the `@SuppressWarnings("<CheckerName>")` annotation. For
 the `DeprecatedApi` checker, `@SuppressWarnings({"deprecation", "DeprecatedApi"})` suppresses both
 compiler and error-prone checker warnings. This is necessary as `DeprecatedApi` can be more
 restrictive than the compiler deprecation check.
-
-## Usage
 
 To use the checkers configure your project to build with the Error Prone Java compiler and add
 `error-prone-checks` annotation processor.

--- a/src/main/java/io/starburst/errorprone/RequireNonNullMessageChecker.java
+++ b/src/main/java/io/starburst/errorprone/RequireNonNullMessageChecker.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+package io.starburst.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LiteralTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.sun.source.tree.Tree.Kind.IDENTIFIER;
+import static com.sun.source.tree.Tree.Kind.STRING_LITERAL;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "RequireNonNullMessage",
+        summary = "An error message provided to Objects#requireNonNull is incorrect",
+        explanation = """
+                The error message passed as the second argument to Objects#requireNonNull \
+                should make it immediately obvious which value is null; the check will trigger when \
+                an identifier is passes as the first argument to Objects#requireNonNull, \
+                but the error message passes as the second argument does not mention its name.""",
+        linkType = BugPattern.LinkType.NONE,
+        severity = BugPattern.SeverityLevel.WARNING)
+public class RequireNonNullMessageChecker
+        extends BugChecker
+        implements MethodInvocationTreeMatcher
+{
+    private static final Pattern MESSAGE_PATTERN = Pattern.compile(" (?:(?:is|are|was|were) (?:null|empty|missing|none)|(?:is|are) required|(?:must not|cannot|can't) be (?:null|empty))");
+    private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("^\\p{javaUnicodeIdentifierStart}\\p{javaUnicodeIdentifierPart}*\\b");
+
+    private static final Matcher<ExpressionTree> requireNonNull = staticMethod()
+            .onClass(Objects.class.getName())
+            .named("requireNonNull");
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state)
+    {
+        if (!requireNonNull.matches(tree, state)) {
+            return NO_MATCH;
+        }
+        List<? extends ExpressionTree> arguments = tree.getArguments();
+        if (arguments.isEmpty()) {
+            // weird
+            return NO_MATCH;
+        }
+
+        // no error message at all:
+        if (arguments.size() < 2) {
+            // this is considered fine: it's probably just a sanity check
+            // (we could enable it at some point, but let's just focus on typos for now)
+            return NO_MATCH;
+        }
+
+        // the first argument: identifier or an expression?
+        ExpressionTree objectArgument = arguments.get(0);
+        if (objectArgument.getKind() != IDENTIFIER) {
+            // we don't want to deal with complex expressions; we only want to detect typos in simple cases
+            return NO_MATCH;
+        }
+        String objectArgumentIdentifier = requireNonNull(state.getSourceForNode(objectArgument));
+
+        // inspect the message
+        ExpressionTree messageArgument = arguments.get(1);
+        if (messageArgument.getKind() != STRING_LITERAL) {
+            // something else than a literal: ignore, since we can't inspect it
+            // TODO: suggest using message supplier
+            return NO_MATCH;
+        }
+        String messageLiteral = (String) ((LiteralTree) messageArgument).getValue();
+
+        // we will first see if we can recognize the error message as "X is null" kind of thing, then proceed accordingly
+        // note: there's no end-of-string anchor in the pattern, so we allow extra information at the end of the message
+        // (and it starts with a space instead of the start-of-string anchor!)
+        java.util.regex.Matcher patternMatch = MESSAGE_PATTERN.matcher(messageLiteral);
+        if (!patternMatch.find()) {
+            // the message does not fit the pattern - must be some free-form text which we won't try to interpret
+            // checks in constructors are a special case, though, so require that the message is equal to the identifier's name
+            if (isWithinConstructor(state) && !messageLiteral.equals(objectArgumentIdentifier)) {
+                return describeMatch(tree, (LiteralTree) messageArgument, objectArgumentIdentifier, " is null", "");
+            }
+
+            return NO_MATCH;
+        }
+
+        // now that we know it's "X is null" kind of thing, let's interpret the "X" part
+        // note: the pattern ends with a word-break, so we won't get a positive match
+        // if only part of the beginning is recognizable as an identifier
+        java.util.regex.Matcher identifierMatch = IDENTIFIER_PATTERN.matcher(messageLiteral);
+        if (!identifierMatch.find()) {
+            // the thing before the pattern is not an identifier at all: ignore, but not in constructors
+            if (isWithinConstructor(state)) {
+                return describeMatch(tree, (LiteralTree) messageArgument, objectArgumentIdentifier, patternMatch.group(), messageLiteral.substring(patternMatch.end()));
+            }
+
+            return NO_MATCH;
+        }
+
+        if (identifierMatch.end() != patternMatch.start()) {
+            // the thing before the pattern is an identifier, but with some extra bits
+            // after the word-break: ignore, but not in constructors
+            // (e.g. 'requireNonNull(parameter, "parameter somehow is null")' is fine)
+            if (isWithinConstructor(state) && !identifierMatch.group().equals(objectArgumentIdentifier)) {
+                return describeMatch(tree, (LiteralTree) messageArgument, objectArgumentIdentifier, patternMatch.group(), messageLiteral.substring(patternMatch.end()));
+            }
+
+            return NO_MATCH;
+        }
+
+        if (identifierMatch.group().equals(objectArgumentIdentifier)) {
+            // not a typo: no error
+            return NO_MATCH;
+        }
+
+        // looks like something we're looking for: success!
+        return describeMatch(tree, (LiteralTree) messageArgument, objectArgumentIdentifier, patternMatch.group(), messageLiteral.substring(patternMatch.end()));
+    }
+
+    private Description describeMatch(MethodInvocationTree tree, LiteralTree messageArgument, String objectArgumentIdentifier, String pattern, String suffix)
+    {
+        return describeMatch(
+                tree,
+                SuggestedFix.replace(
+                        messageArgument,
+                        format("\"%s%s%s\"", objectArgumentIdentifier, pattern, suffix)));
+    }
+
+    private boolean isWithinConstructor(VisitorState state)
+    {
+        MethodTree enclosingMethodTree = state.findEnclosing(MethodTree.class);
+        return enclosingMethodTree != null && getSymbol(enclosingMethodTree).isConstructor();
+    }
+}

--- a/src/test/java/io/starburst/errorprone/TestRequireNonNullMessageChecker.java
+++ b/src/test/java/io/starburst/errorprone/TestRequireNonNullMessageChecker.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+package io.starburst.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.Test;
+
+public class TestRequireNonNullMessageChecker
+{
+    private CompilationTestHelper compilationTestHelper()
+    {
+        return CompilationTestHelper.newInstance(RequireNonNullMessageChecker.class, getClass());
+    }
+
+    @Test
+    public void testNegativeCases()
+    {
+        compilationTestHelper().addSourceFile("testdata/RequireNonNullMessageNegativeCases.java").doTest();
+    }
+
+    @Test
+    public void testPositiveCases()
+    {
+        compilationTestHelper().addSourceFile("testdata/RequireNonNullMessagePositiveCases.java").doTest();
+    }
+}

--- a/src/test/java/io/starburst/errorprone/testdata/RequireNonNullMessageNegativeCases.java
+++ b/src/test/java/io/starburst/errorprone/testdata/RequireNonNullMessageNegativeCases.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+package io.starburst.errorprone.testdata;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class RequireNonNullMessageNegativeCases
+{
+    private Object placeholder;
+
+    @SuppressWarnings("RegexpSingleline") // "Objects.requireNonNull should only be used with static imports" - we do it on purpose
+    public RequireNonNullMessageNegativeCases(Object fullPatternInConstructorWithoutStaticImport)
+    {
+        this.placeholder = Objects.requireNonNull(fullPatternInConstructorWithoutStaticImport, "fullPatternInConstructorWithoutStaticImport is null");
+    }
+
+    public RequireNonNullMessageNegativeCases(Byte bareIdentifierInConstructor)
+    {
+        this.placeholder = requireNonNull(bareIdentifierInConstructor, "bareIdentifierInConstructor");
+    }
+
+    public RequireNonNullMessageNegativeCases(Byte fullPatternInConstructor, int dummy)
+    {
+        this.placeholder = requireNonNull(fullPatternInConstructor, "fullPatternInConstructor is null");
+    }
+
+    public RequireNonNullMessageNegativeCases(Byte fullPatternWithInfixInConstructor, long dummy)
+    {
+        this.placeholder = requireNonNull(fullPatternWithInfixInConstructor, "fullPatternWithInfixInConstructor clearly is null");
+    }
+
+    public RequireNonNullMessageNegativeCases(Boolean fullPatternNestedInConstructor)
+    {
+        if (true == false) {
+            for (String s : List.of("a", "b", "c")) {
+                this.placeholder = requireNonNull(fullPatternNestedInConstructor, "fullPatternNestedInConstructor is null");
+            }
+        }
+    }
+
+    public RequireNonNullMessageNegativeCases(Integer messageMissingInConstructor)
+    {
+        // this is considered fine: just a quick sanity check
+        this.placeholder = requireNonNull(messageMissingInConstructor);
+    }
+
+    public RequireNonNullMessageNegativeCases(String complexExpressionInConstructor)
+    {
+        // we only want to find typos and other simple cases, so ignore complex expressions
+        this.placeholder = requireNonNull(getClass(), "I don't like this parameter");
+    }
+
+    @SuppressWarnings("RegexpSingleline") // "Objects.requireNonNull should only be used with static imports" - we do it on purpose
+    public void fullPatternInMethodWithoutStaticImport(String parameter)
+    {
+        this.placeholder = Objects.requireNonNull(parameter, "parameter is null");
+    }
+
+    public void bareIdentifierInMethod(Object parameter)
+    {
+        this.placeholder = requireNonNull(parameter, "parameter");
+    }
+
+    public void fullPatternInMethod(Object parameter)
+    {
+        this.placeholder = requireNonNull(parameter, "parameter is null");
+    }
+
+    public void fullPatternWithInfixInMethod(Object parameter)
+    {
+        this.placeholder = requireNonNull(parameter, "parameter clearly is null");
+    }
+
+    public void fullPatternNestedInMethod(Object parameter)
+    {
+        if (true == false) {
+            for (String s : List.of("a", "b", "c")) {
+                this.placeholder = requireNonNull(parameter, "parameter is null");
+            }
+        }
+    }
+
+    public void messageMissingInMethod(String parameter)
+    {
+        // this is considered fine: just check the stack trace
+        this.placeholder = requireNonNull(parameter);
+    }
+
+    public void messageAlmostMalformedInMethod(String parameter)
+    {
+        // we're only flagging cases where the entire thing before the pattern looks like an identifier
+        this.placeholder = requireNonNull(parameter, "my argument is null");
+    }
+
+    public void messageNotFittingPatternInMethod(String parameter)
+    {
+        // someone wanted to provide a more descriptive message, and this is fine
+        this.placeholder = requireNonNull(parameter, "I don't like this parameter");
+    }
+
+    public void complexExpressionInMethod(String parameter)
+    {
+        // we only want to find typos and other simple cases, so ignore complex expressions
+        this.placeholder = requireNonNull(parameter.getClass(), "I don't like this parameter");
+    }
+}

--- a/src/test/java/io/starburst/errorprone/testdata/RequireNonNullMessagePositiveCases.java
+++ b/src/test/java/io/starburst/errorprone/testdata/RequireNonNullMessagePositiveCases.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+package io.starburst.errorprone.testdata;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class RequireNonNullMessagePositiveCases
+{
+    private Object placeholder;
+
+    @SuppressWarnings("RegexpSingleline") // "Objects.requireNonNull should only be used with static imports" - we do it on purpose
+    public RequireNonNullMessagePositiveCases(Integer messageMalformedInConstructorWithStaticImport)
+    {
+        // BUG: Diagnostic contains: RequireNonNullMessage
+        // Did you mean 'this.placeholder = Objects.requireNonNull(messageMalformedInConstructorWithStaticImport, "messageMalformedInConstructorWithStaticImport is null");'?
+        this.placeholder = Objects.requireNonNull(messageMalformedInConstructorWithStaticImport, "messageMissingInConstructor is null");
+    }
+
+    public RequireNonNullMessagePositiveCases(Long messageMalformedInConstructor)
+    {
+        // BUG: Diagnostic contains: RequireNonNullMessage
+        // Did you mean 'this.placeholder = requireNonNull(messageMalformedInConstructor, "messageMalformedInConstructor is null");'?
+        this.placeholder = requireNonNull(messageMalformedInConstructor, "messageMissingInConstructor is null");
+    }
+
+    public RequireNonNullMessagePositiveCases(Character messageMalformedNestedInConstructor)
+    {
+        if (true == false) {
+            for (String s : List.of("a", "b", "c")) {
+                // BUG: Diagnostic contains: RequireNonNullMessage
+                // Did you mean 'this.placeholder = requireNonNull(messageMalformedNestedInConstructor, "messageMalformedNestedInConstructor is null");'?
+                this.placeholder = requireNonNull(messageMalformedNestedInConstructor, "messageMissingInConstructor is null");
+            }
+        }
+    }
+
+    public RequireNonNullMessagePositiveCases(Float messageAlmostMalformedInConstructor)
+    {
+        // looks like an identifier, but it's not our identifier
+        // BUG: Diagnostic contains: RequireNonNullMessage
+        // Did you mean 'this.placeholder = requireNonNull(messageAlmostMalformedInConstructor, "messageAlmostMalformedInConstructor is null");'?
+        this.placeholder = requireNonNull(messageAlmostMalformedInConstructor, "my argument is null");
+    }
+
+    public RequireNonNullMessagePositiveCases(Double messageNotFittingPatternInConstructor)
+    {
+        // BUG: Diagnostic contains: RequireNonNullMessage
+        // Did you mean 'this.placeholder = requireNonNull(messageNotFittingPatternInConstructor, "messageNotFittingPatternInConstructor is null");'?
+        this.placeholder = requireNonNull(messageNotFittingPatternInConstructor, "I don't like this parameter");
+    }
+
+    public void messageMalformedInMethod(String parameter)
+    {
+        // BUG: Diagnostic contains: RequireNonNullMessage
+        // Did you mean 'this.placeholder = requireNonNull(parameter, "parameter is null");'?
+        this.placeholder = requireNonNull(parameter, "argument is null");
+    }
+
+    public void messageMalformedNestedInMethod(String parameter)
+    {
+        if (true == false) {
+            for (String s : List.of("a", "b", "c")) {
+                // BUG: Diagnostic contains: RequireNonNullMessage
+                // Did you mean 'this.placeholder = requireNonNull(parameter, "parameter is null");'?
+                this.placeholder = requireNonNull(parameter, "argument is null");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a check to find some common cases of malformed `requireNonNull` calls. See the documentation for more details.

Based on trinodb/trino#10473 but is *slightly* more restrictive than that one (it always disallows the case when the part before the " is null" part is not the required identifier, while the other check only disallows it in constructors).