### PR TITLE
Fix false positive when parent class is ignored

### DIFF
--- a/src/main/java/io/starburst/errorprone/AnnotatedApiUsageChecker.java
+++ b/src/main/java/io/starburst/errorprone/AnnotatedApiUsageChecker.java
@@ -164,9 +164,12 @@ public abstract class AnnotatedApiUsageChecker
      */
     private boolean isAnnotatedApi(Symbol symbol)
     {
-        Name name = symbol.getQualifiedName();
-        if (name != null && ignoredTypes.contains(name.toString())) {
-            return false;
+        // checking if type is ignored only makes sense for types:
+        if (symbol.getKind() == CLASS) {
+            Name name = symbol.getQualifiedName();
+            if (name != null && ignoredTypes.contains(name.toString())) {
+                return false;
+            }
         }
 
         for (AnnotationMirror annotation : symbol.getAnnotationMirrors()) {

--- a/src/main/java/io/starburst/errorprone/AnnotatedApiUsageChecker.java
+++ b/src/main/java/io/starburst/errorprone/AnnotatedApiUsageChecker.java
@@ -174,7 +174,11 @@ public abstract class AnnotatedApiUsageChecker
 
         for (AnnotationMirror annotation : symbol.getAnnotationMirrors()) {
             if (annotation.getAnnotationType().toString().equals(annotationType)) {
-                return true;
+                if (symbol.owner == null || symbol.owner.getKind() != CLASS) {
+                    return true;
+                }
+                Name ownerName = symbol.owner.getQualifiedName();
+                return ownerName == null || !ignoredTypes.contains(ownerName.toString());
             }
         }
 

--- a/src/main/java/io/starburst/errorprone/AnnotatedApiUsageChecker.java
+++ b/src/main/java/io/starburst/errorprone/AnnotatedApiUsageChecker.java
@@ -30,6 +30,7 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Name;
 
+import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -61,7 +62,7 @@ public abstract class AnnotatedApiUsageChecker
      * it's declared in) is annotated. This is used to prevent things like type parameters that happen
      * to be declared in an annotated class from being flagged.
      */
-    private static final Set<ElementKind> INHERITS_ANNOTATION_FROM_OWNER = Set.of(
+    private static final Set<ElementKind> INHERITS_ANNOTATION_FROM_OWNER = EnumSet.of(
             FIELD, METHOD, CONSTRUCTOR, ENUM_CONSTANT, CLASS, INTERFACE, ENUM, ANNOTATION_TYPE);
 
     private final String annotationType;

--- a/src/test/java/io/starburst/errorprone/TestDeprecatedApiChecker.java
+++ b/src/test/java/io/starburst/errorprone/TestDeprecatedApiChecker.java
@@ -42,52 +42,36 @@ public class TestDeprecatedApiChecker
     @Test
     public void testNegativeCasesWithIgnoredPackages()
     {
-        String path = "Test.java";
-        String lines = """
-                import io.trino.spi.ignored.IgnoredDeprecatedClass;
-                public class Test {
-                    private IgnoredDeprecatedClass asField;
-                }
-                """;
-
         // API package is ignored
         compilationTestHelper()
-                .setArgs("-XepOpt:DeprecatedApi:IgnoredPackages=io.trino.spi.ignored")
-                .addSourceLines(path, lines)
+                .setArgs("-XepOpt:DeprecatedApi:IgnoredPackages=io.trino.spi.deprecated")
+                .addSourceFile("DeprecatedApiNegativeCasesIgnored.java")
                 .doTest();
 
         // API package matches base but is ignored
         compilationTestHelper()
                 .setArgs(
                         "-XepOpt:DeprecatedApi:BasePackages=io.trino.spi",
-                        "-XepOpt:DeprecatedApi:IgnoredPackages=io.trino.spi.ignored")
-                .addSourceLines(path, lines)
+                        "-XepOpt:DeprecatedApi:IgnoredPackages=io.trino.spi.deprecated")
+                .addSourceFile("DeprecatedApiNegativeCasesIgnored.java")
                 .doTest();
     }
 
     @Test
     public void testNegativeCasesWithIgnoredTypes()
     {
-        String path = "Test.java";
-        String lines = """
-                import io.trino.spi.ignored.IgnoredDeprecatedClass;
-                public class Test {
-                    private IgnoredDeprecatedClass asField;
-                }
-                """;
-
         // API package is ignored
         compilationTestHelper()
-                .setArgs("-XepOpt:DeprecatedApi:IgnoredTypes=io.trino.spi.ignored.IgnoredDeprecatedClass")
-                .addSourceLines(path, lines)
+                .setArgs("-XepOpt:DeprecatedApi:IgnoredTypes=io.trino.spi.deprecated.DeprecatedClass,io.trino.spi.deprecated.ClassWithDeprecatedMember")
+                .addSourceFile("DeprecatedApiNegativeCasesIgnored.java")
                 .doTest();
 
         // API package matches base but is ignored
         compilationTestHelper()
                 .setArgs(
                         "-XepOpt:DeprecatedApi:BasePackages=io.trino.spi",
-                        "-XepOpt:DeprecatedApi:IgnoredTypes=io.trino.spi.ignored.IgnoredDeprecatedClass")
-                .addSourceLines(path, lines)
+                        "-XepOpt:DeprecatedApi:IgnoredTypes=io.trino.spi.deprecated.DeprecatedClass,io.trino.spi.deprecated.ClassWithDeprecatedMember")
+                .addSourceFile("DeprecatedApiNegativeCasesIgnored.java")
                 .doTest();
     }
 

--- a/src/test/java/io/starburst/errorprone/TestTrinoExperimentalSpiChecker.java
+++ b/src/test/java/io/starburst/errorprone/TestTrinoExperimentalSpiChecker.java
@@ -28,6 +28,12 @@ public class TestTrinoExperimentalSpiChecker
     }
 
     @Test
+    public void testNegativeCasesSuppressed()
+    {
+        compilationTestHelper().addSourceFile("TrinoExperimentalSpiNegativeCasesSuppressed.java").doTest();
+    }
+
+    @Test
     public void testPositiveCases()
     {
         compilationTestHelper().addSourceFile("TrinoExperimentalSpiPositiveCases.java").doTest();

--- a/src/test/java/io/starburst/errorprone/TestTrinoExperimentalSpiChecker.java
+++ b/src/test/java/io/starburst/errorprone/TestTrinoExperimentalSpiChecker.java
@@ -42,52 +42,36 @@ public class TestTrinoExperimentalSpiChecker
     @Test
     public void testNegativeCasesWithIgnoredPackages()
     {
-        String path = "Test.java";
-        String lines = """
-                import io.trino.spi.ignored.IgnoredExperimentalClass;
-                public class Test {
-                    private IgnoredExperimentalClass asField;
-                }
-                """;
-
         // SPI package is ignored
         compilationTestHelper()
-                .setArgs("-XepOpt:TrinoExperimentalSpi:IgnoredPackages=io.trino.spi.ignored")
-                .addSourceLines(path, lines)
+                .setArgs("-XepOpt:TrinoExperimentalSpi:IgnoredPackages=io.trino.spi.experimental")
+                .addSourceFile("TrinoExperimentalSpiNegativeCasesIgnored.java")
                 .doTest();
 
         // SPI package matches base but is ignored
         compilationTestHelper()
                 .setArgs(
                         "-XepOpt:TrinoExperimentalSpi:BasePackages=io.trino.spi",
-                        "-XepOpt:TrinoExperimentalSpi:IgnoredPackages=io.trino.spi.ignored")
-                .addSourceLines(path, lines)
+                        "-XepOpt:TrinoExperimentalSpi:IgnoredPackages=io.trino.spi.experimental")
+                .addSourceFile("TrinoExperimentalSpiNegativeCasesIgnored.java")
                 .doTest();
     }
 
     @Test
     public void testNegativeCasesWithIgnoredTypes()
     {
-        String path = "Test.java";
-        String lines = """
-                import io.trino.spi.ignored.IgnoredExperimentalClass;
-                public class Test {
-                    private IgnoredExperimentalClass asField;
-                }
-                """;
-
         // SPI class is ignored
         compilationTestHelper()
-                .setArgs("-XepOpt:TrinoExperimentalSpi:IgnoredTypes=io.trino.spi.ignored.IgnoredExperimentalClass")
-                .addSourceLines(path, lines)
+                .setArgs("-XepOpt:TrinoExperimentalSpi:IgnoredTypes=io.trino.spi.experimental.ExperimentalClass,io.trino.spi.experimental.ClassWithExperimentalMember")
+                .addSourceFile("TrinoExperimentalSpiNegativeCasesIgnored.java")
                 .doTest();
 
         // SPI package matches base but the class is ignored
         compilationTestHelper()
                 .setArgs(
                         "-XepOpt:TrinoExperimentalSpi:BasePackages=io.trino.spi",
-                        "-XepOpt:TrinoExperimentalSpi:IgnoredTypes=io.trino.spi.ignored.IgnoredExperimentalClass")
-                .addSourceLines(path, lines)
+                        "-XepOpt:TrinoExperimentalSpi:IgnoredTypes=io.trino.spi.experimental.ExperimentalClass,io.trino.spi.experimental.ClassWithExperimentalMember")
+                .addSourceFile("TrinoExperimentalSpiNegativeCasesIgnored.java")
                 .doTest();
     }
 

--- a/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiNegativeCases.java
+++ b/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiNegativeCases.java
@@ -15,6 +15,7 @@ import io.trino.spi.deprecated.NotDeprecatedClass;
 
 import java.util.List;
 
+@SuppressWarnings("unused")
 public class DeprecatedApiNegativeCases
 {
     private final Object instantiation = new NotDeprecatedClass();
@@ -51,6 +52,7 @@ public class DeprecatedApiNegativeCases
     public static class Overrides
             extends ClassWithDeprecatedMember
     {
+        @SuppressWarnings("RedundantMethodOverride")
         @Override
         public void notDeprecated()
         {}

--- a/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiNegativeCases.java
+++ b/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiNegativeCases.java
@@ -15,6 +15,8 @@ import io.trino.spi.deprecated.NotDeprecatedClass;
 
 import java.util.List;
 
+import static io.trino.spi.deprecated.NotDeprecatedClass.STATIC_MEMBER;
+
 @SuppressWarnings("unused")
 public class DeprecatedApiNegativeCases
 {
@@ -43,6 +45,16 @@ public class DeprecatedApiNegativeCases
     public NotDeprecatedClass asReturnType()
     {
         return null;
+    }
+
+    public void referencingStaticMember()
+    {
+        String ignore = NotDeprecatedClass.STATIC_MEMBER;
+    }
+
+    public void referencingStaticMemberAsStaticImport()
+    {
+        String ignore = STATIC_MEMBER;
     }
 
     public static class AsBaseClass

--- a/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiNegativeCasesIgnored.java
+++ b/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiNegativeCasesIgnored.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package io.starburst.errorprone.testdata;
+
+import io.trino.spi.deprecated.ClassWithDeprecatedMember;
+import io.trino.spi.deprecated.DeprecatedClass;
+
+import java.util.List;
+
+import static io.trino.spi.deprecated.DeprecatedClass.STATIC_MEMBER;
+
+@SuppressWarnings({"deprecation", "unused"})
+public class DeprecatedApiNegativeCasesIgnored
+{
+    private final Object instantiation = new DeprecatedClass();
+
+    private DeprecatedClass asField;
+
+    private final ClassWithDeprecatedMember classWithMember = new ClassWithDeprecatedMember();
+
+    public void asParameter(DeprecatedClass param)
+    {}
+
+    public void asTypeArgument(List<DeprecatedClass> param)
+    {}
+
+    public void asLocalVariable()
+    {
+        DeprecatedClass var;
+    }
+
+    public void methodCall()
+    {
+        classWithMember.deprecated();
+    }
+
+    public DeprecatedClass asReturnType()
+    {
+        return null;
+    }
+
+    public void referencingStaticMember()
+    {
+        String ignore = DeprecatedClass.STATIC_MEMBER;
+    }
+
+    public void referencingStaticMemberAsStaticImport()
+    {
+        String ignore = STATIC_MEMBER;
+    }
+
+    public static class AsBaseClass
+            extends DeprecatedClass
+    {}
+
+    public static class Overrides
+            extends ClassWithDeprecatedMember
+    {
+        @Override
+        public void deprecated()
+        {}
+    }
+}

--- a/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiNegativeCasesSuppressed.java
+++ b/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiNegativeCasesSuppressed.java
@@ -15,6 +15,8 @@ import io.trino.spi.deprecated.DeprecatedClass;
 
 import java.util.List;
 
+import static io.trino.spi.deprecated.DeprecatedClass.STATIC_MEMBER;
+
 @SuppressWarnings({"deprecation", "unused"})
 public class DeprecatedApiNegativeCasesSuppressed
 {
@@ -50,6 +52,18 @@ public class DeprecatedApiNegativeCasesSuppressed
     public DeprecatedClass asReturnType()
     {
         return null;
+    }
+
+    public void referencingStaticMember()
+    {
+        @SuppressWarnings("DeprecatedApi")
+        String ignore = DeprecatedClass.STATIC_MEMBER;
+    }
+
+    public void referencingStaticMemberAsStaticImport()
+    {
+        @SuppressWarnings("DeprecatedApi")
+        String ignore = STATIC_MEMBER;
     }
 
     @SuppressWarnings("DeprecatedApi")

--- a/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiNegativeCasesSuppressed.java
+++ b/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiNegativeCasesSuppressed.java
@@ -12,6 +12,8 @@ package io.starburst.errorprone.testdata;
 
 import io.trino.spi.deprecated.ClassWithDeprecatedMember;
 import io.trino.spi.deprecated.DeprecatedClass;
+import io.trino.spi.deprecated.DeprecatedEnum;
+import io.trino.spi.deprecated.DeprecatedRecord;
 
 import java.util.List;
 
@@ -24,7 +26,16 @@ public class DeprecatedApiNegativeCasesSuppressed
     private final Object instantiation = new DeprecatedClass();
 
     @SuppressWarnings("DeprecatedApi")
+    private final Object instantiationRecord = new DeprecatedRecord("foo");
+
+    @SuppressWarnings("DeprecatedApi")
     private DeprecatedClass asField;
+
+    @SuppressWarnings("DeprecatedApi")
+    private DeprecatedEnum asEnumField;
+
+    @SuppressWarnings("DeprecatedApi")
+    private DeprecatedRecord asRecordField;
 
     private final ClassWithDeprecatedMember classWithMember = new ClassWithDeprecatedMember();
 
@@ -33,13 +44,35 @@ public class DeprecatedApiNegativeCasesSuppressed
     {}
 
     @SuppressWarnings("DeprecatedApi")
+    public void asParameter(DeprecatedEnum param)
+    {}
+
+    @SuppressWarnings("DeprecatedApi")
+    public void asParameter(DeprecatedRecord param)
+    {}
+
+    @SuppressWarnings("DeprecatedApi")
     public void asTypeArgument(List<DeprecatedClass> param)
+    {}
+
+    @SuppressWarnings("DeprecatedApi")
+    public void asTypeArgumentEnum(List<DeprecatedEnum> param)
+    {}
+
+    @SuppressWarnings("DeprecatedApi")
+    public void asTypeArgumentRecord(List<DeprecatedRecord> param)
     {}
 
     public void asLocalVariable()
     {
         @SuppressWarnings("DeprecatedApi")
         DeprecatedClass var;
+
+        @SuppressWarnings("DeprecatedApi")
+        DeprecatedEnum varEnum;
+
+        @SuppressWarnings("DeprecatedApi")
+        DeprecatedRecord varRecord;
     }
 
     @SuppressWarnings("DeprecatedApi")
@@ -64,6 +97,18 @@ public class DeprecatedApiNegativeCasesSuppressed
     {
         @SuppressWarnings("DeprecatedApi")
         String ignore = STATIC_MEMBER;
+    }
+
+    @SuppressWarnings("DeprecatedApi")
+    public DeprecatedEnum asReturnTypeEnum()
+    {
+        return null;
+    }
+
+    @SuppressWarnings("DeprecatedApi")
+    public DeprecatedEnum asReturnTypeRecord()
+    {
+        return null;
     }
 
     @SuppressWarnings("DeprecatedApi")

--- a/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiNegativeCasesSuppressed.java
+++ b/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiNegativeCasesSuppressed.java
@@ -15,43 +15,44 @@ import io.trino.spi.deprecated.DeprecatedClass;
 
 import java.util.List;
 
+@SuppressWarnings({"deprecation", "unused"})
 public class DeprecatedApiNegativeCasesSuppressed
 {
-    @SuppressWarnings({"deprecation", "DeprecatedApi"})
+    @SuppressWarnings("DeprecatedApi")
     private final Object instantiation = new DeprecatedClass();
 
-    @SuppressWarnings({"deprecation", "DeprecatedApi"})
+    @SuppressWarnings("DeprecatedApi")
     private DeprecatedClass asField;
 
     private final ClassWithDeprecatedMember classWithMember = new ClassWithDeprecatedMember();
 
-    @SuppressWarnings({"deprecation", "DeprecatedApi"})
+    @SuppressWarnings("DeprecatedApi")
     public void asParameter(DeprecatedClass param)
     {}
 
-    @SuppressWarnings({"deprecation", "DeprecatedApi"})
+    @SuppressWarnings("DeprecatedApi")
     public void asTypeArgument(List<DeprecatedClass> param)
     {}
 
     public void asLocalVariable()
     {
-        @SuppressWarnings({"deprecation", "DeprecatedApi"})
+        @SuppressWarnings("DeprecatedApi")
         DeprecatedClass var;
     }
 
-    @SuppressWarnings({"deprecation", "DeprecatedApi"})
+    @SuppressWarnings("DeprecatedApi")
     public void methodCall()
     {
         classWithMember.deprecated();
     }
 
-    @SuppressWarnings({"deprecation", "DeprecatedApi"})
+    @SuppressWarnings("DeprecatedApi")
     public DeprecatedClass asReturnType()
     {
         return null;
     }
 
-    @SuppressWarnings({"deprecation", "DeprecatedApi"})
+    @SuppressWarnings("DeprecatedApi")
     public static class AsBaseClass
             extends DeprecatedClass
     {}
@@ -59,7 +60,7 @@ public class DeprecatedApiNegativeCasesSuppressed
     public static class Overrides
             extends ClassWithDeprecatedMember
     {
-        @SuppressWarnings({"deprecation", "DeprecatedApi"})
+        @SuppressWarnings("DeprecatedApi")
         @Override
         public void deprecated()
         {}

--- a/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiPositiveCases.java
+++ b/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiPositiveCases.java
@@ -15,6 +15,8 @@ import io.trino.spi.deprecated.DeprecatedClass;
 
 import java.util.List;
 
+import static io.trino.spi.deprecated.DeprecatedClass.STATIC_MEMBER;
+
 @SuppressWarnings({"deprecation", "unused"})
 public class DeprecatedApiPositiveCases
 {
@@ -50,6 +52,18 @@ public class DeprecatedApiPositiveCases
     public DeprecatedClass asReturnType()
     {
         return null;
+    }
+
+    public void referencingStaticMember()
+    {
+        // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+        String ignore = DeprecatedClass.STATIC_MEMBER;
+    }
+
+    public void referencingStaticMemberAsStaticImport()
+    {
+        // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+        String ignore = STATIC_MEMBER;
     }
 
     public static class AsBaseClass

--- a/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiPositiveCases.java
+++ b/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiPositiveCases.java
@@ -12,6 +12,8 @@ package io.starburst.errorprone.testdata;
 
 import io.trino.spi.deprecated.ClassWithDeprecatedMember;
 import io.trino.spi.deprecated.DeprecatedClass;
+import io.trino.spi.deprecated.DeprecatedEnum;
+import io.trino.spi.deprecated.DeprecatedRecord;
 
 import java.util.List;
 
@@ -24,7 +26,16 @@ public class DeprecatedApiPositiveCases
     private final Object instantiation = new DeprecatedClass();
 
     // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+    private final Object instantiationRecord = new DeprecatedRecord("foo");
+
+    // BUG: Diagnostic contains: Do not use @Deprecated APIs.
     private DeprecatedClass asField;
+
+    // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+    private DeprecatedEnum asEnumField;
+
+    // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+    private DeprecatedRecord asRecordField;
 
     private final ClassWithDeprecatedMember classWithMember = new ClassWithDeprecatedMember();
 
@@ -33,13 +44,35 @@ public class DeprecatedApiPositiveCases
     {}
 
     // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+    public void asParameter(DeprecatedEnum param)
+    {}
+
+    // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+    public void asParameter(DeprecatedRecord param)
+    {}
+
+    // BUG: Diagnostic contains: Do not use @Deprecated APIs.
     public void asTypeArgument(List<DeprecatedClass> param)
+    {}
+
+    // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+    public void asTypeArgumentEnum(List<DeprecatedEnum> param)
+    {}
+
+    // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+    public void asTypeArgumentRecord(List<DeprecatedRecord> param)
     {}
 
     public void asLocalVariable()
     {
         // BUG: Diagnostic contains: Do not use @Deprecated APIs.
         DeprecatedClass var;
+
+        // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+        DeprecatedEnum varEnum;
+
+        // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+        DeprecatedRecord varRecord;
     }
 
     public void methodCall()
@@ -50,6 +83,18 @@ public class DeprecatedApiPositiveCases
 
     // BUG: Diagnostic contains: Do not use @Deprecated APIs.
     public DeprecatedClass asReturnType()
+    {
+        return null;
+    }
+
+    // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+    public DeprecatedEnum asReturnTypeEnum()
+    {
+        return null;
+    }
+
+    // BUG: Diagnostic contains: Do not use @Deprecated APIs.
+    public DeprecatedRecord asReturnTypeRecord()
     {
         return null;
     }

--- a/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiPositiveCases.java
+++ b/src/test/java/io/starburst/errorprone/testdata/DeprecatedApiPositiveCases.java
@@ -15,6 +15,7 @@ import io.trino.spi.deprecated.DeprecatedClass;
 
 import java.util.List;
 
+@SuppressWarnings({"deprecation", "unused"})
 public class DeprecatedApiPositiveCases
 {
     // BUG: Diagnostic contains: Do not use @Deprecated APIs.

--- a/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiNegativeCases.java
+++ b/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiNegativeCases.java
@@ -15,6 +15,8 @@ import io.trino.spi.experimental.NotExperimentalClass;
 
 import java.util.List;
 
+import static io.trino.spi.experimental.NotExperimentalClass.STATIC_MEMBER;
+
 @SuppressWarnings("unused")
 public class TrinoExperimentalSpiNegativeCases
 {
@@ -43,6 +45,16 @@ public class TrinoExperimentalSpiNegativeCases
     public NotExperimentalClass asReturnType()
     {
         return null;
+    }
+
+    public void referencingStaticMember()
+    {
+        String ignore = NotExperimentalClass.STATIC_MEMBER;
+    }
+
+    public void referencingStaticMemberAsStaticImport()
+    {
+        String ignore = STATIC_MEMBER;
     }
 
     public static class AsBaseClass

--- a/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiNegativeCases.java
+++ b/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiNegativeCases.java
@@ -15,6 +15,7 @@ import io.trino.spi.experimental.NotExperimentalClass;
 
 import java.util.List;
 
+@SuppressWarnings("unused")
 public class TrinoExperimentalSpiNegativeCases
 {
     private final Object instantiation = new NotExperimentalClass();
@@ -51,6 +52,7 @@ public class TrinoExperimentalSpiNegativeCases
     public static class Overrides
             extends ClassWithExperimentalMember
     {
+        @SuppressWarnings("RedundantMethodOverride")
         @Override
         public void notExperimental()
         {}

--- a/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiNegativeCasesIgnored.java
+++ b/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiNegativeCasesIgnored.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package io.starburst.errorprone.testdata;
+
+import io.trino.spi.experimental.ClassWithExperimentalMember;
+import io.trino.spi.experimental.ExperimentalClass;
+
+import java.util.List;
+
+import static io.trino.spi.experimental.ExperimentalClass.STATIC_MEMBER;
+
+@SuppressWarnings("unused")
+public class TrinoExperimentalSpiNegativeCasesIgnored
+{
+    private final Object instantiation = new ExperimentalClass();
+
+    private ExperimentalClass asField;
+
+    private final ClassWithExperimentalMember classWithMember = new ClassWithExperimentalMember();
+
+    public void asParameter(ExperimentalClass param)
+    {}
+
+    public void asTypeArgument(List<ExperimentalClass> param)
+    {}
+
+    public void asLocalVariable()
+    {
+        ExperimentalClass var;
+    }
+
+    public void methodCall()
+    {
+        classWithMember.experimental();
+    }
+
+    public ExperimentalClass asReturnType()
+    {
+        return null;
+    }
+
+    public void referencingStaticMember()
+    {
+        String ignore = ExperimentalClass.STATIC_MEMBER;
+    }
+
+    public void referencingStaticMemberAsStaticImport()
+    {
+        String ignore = STATIC_MEMBER;
+    }
+
+    public static class AsBaseClass
+            extends ExperimentalClass
+    {}
+
+    public static class Overrides
+            extends ClassWithExperimentalMember
+    {
+        @Override
+        public void experimental()
+        {}
+    }
+}

--- a/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiNegativeCasesSuppressed.java
+++ b/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiNegativeCasesSuppressed.java
@@ -12,6 +12,8 @@ package io.starburst.errorprone.testdata;
 
 import io.trino.spi.experimental.ClassWithExperimentalMember;
 import io.trino.spi.experimental.ExperimentalClass;
+import io.trino.spi.experimental.ExperimentalEnum;
+import io.trino.spi.experimental.ExperimentalRecord;
 
 import java.util.List;
 
@@ -24,7 +26,16 @@ public class TrinoExperimentalSpiNegativeCasesSuppressed
     private final Object instantiation = new ExperimentalClass();
 
     @SuppressWarnings("TrinoExperimentalSpi")
+    private final Object instantiationRecord = new ExperimentalRecord("foo");
+
+    @SuppressWarnings("TrinoExperimentalSpi")
     private ExperimentalClass asField;
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    private ExperimentalEnum asEnumField;
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    private ExperimentalRecord asRecordField;
 
     private final ClassWithExperimentalMember classWithMember = new ClassWithExperimentalMember();
 
@@ -33,13 +44,35 @@ public class TrinoExperimentalSpiNegativeCasesSuppressed
     {}
 
     @SuppressWarnings("TrinoExperimentalSpi")
+    public void asParameter(ExperimentalEnum param)
+    {}
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    public void asParameter(ExperimentalRecord param)
+    {}
+
+    @SuppressWarnings("TrinoExperimentalSpi")
     public void asTypeArgument(List<ExperimentalClass> param)
+    {}
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    public void asTypeArgumentEnum(List<ExperimentalEnum> param)
+    {}
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    public void asTypeArgumentRecord(List<ExperimentalRecord> param)
     {}
 
     public void asLocalVariable()
     {
         @SuppressWarnings("TrinoExperimentalSpi")
         ExperimentalClass var;
+
+        @SuppressWarnings("TrinoExperimentalSpi")
+        ExperimentalEnum varEnum;
+
+        @SuppressWarnings("TrinoExperimentalSpi")
+        ExperimentalRecord varRecord;
     }
 
     @SuppressWarnings("TrinoExperimentalSpi")
@@ -50,6 +83,18 @@ public class TrinoExperimentalSpiNegativeCasesSuppressed
 
     @SuppressWarnings("TrinoExperimentalSpi")
     public ExperimentalClass asReturnType()
+    {
+        return null;
+    }
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    public ExperimentalEnum asReturnTypeEnum()
+    {
+        return null;
+    }
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    public ExperimentalRecord asReturnTypeRecord()
     {
         return null;
     }

--- a/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiNegativeCasesSuppressed.java
+++ b/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiNegativeCasesSuppressed.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package io.starburst.errorprone.testdata;
+
+import io.trino.spi.experimental.ClassWithExperimentalMember;
+import io.trino.spi.experimental.ExperimentalClass;
+
+import java.util.List;
+
+import static io.trino.spi.experimental.ExperimentalClass.STATIC_MEMBER;
+
+@SuppressWarnings("unused")
+public class TrinoExperimentalSpiNegativeCasesSuppressed
+{
+    @SuppressWarnings("TrinoExperimentalSpi")
+    private final Object instantiation = new ExperimentalClass();
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    private ExperimentalClass asField;
+
+    private final ClassWithExperimentalMember classWithMember = new ClassWithExperimentalMember();
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    public void asParameter(ExperimentalClass param)
+    {}
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    public void asTypeArgument(List<ExperimentalClass> param)
+    {}
+
+    public void asLocalVariable()
+    {
+        @SuppressWarnings("TrinoExperimentalSpi")
+        ExperimentalClass var;
+    }
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    public void methodCall()
+    {
+        classWithMember.experimental();
+    }
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    public ExperimentalClass asReturnType()
+    {
+        return null;
+    }
+
+    public void referencingStaticMember()
+    {
+        @SuppressWarnings("TrinoExperimentalSpi")
+        String ignore = ExperimentalClass.STATIC_MEMBER;
+    }
+
+    public void referencingStaticMemberAsStaticImport()
+    {
+        @SuppressWarnings("TrinoExperimentalSpi")
+        String ignore = STATIC_MEMBER;
+    }
+
+    @SuppressWarnings("TrinoExperimentalSpi")
+    public static class AsBaseClass
+            extends ExperimentalClass
+    {}
+
+    public static class Overrides
+            extends ClassWithExperimentalMember
+    {
+        @SuppressWarnings("TrinoExperimentalSpi")
+        @Override
+        public void experimental()
+        {}
+    }
+}

--- a/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiPositiveCases.java
+++ b/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiPositiveCases.java
@@ -15,6 +15,8 @@ import io.trino.spi.experimental.ExperimentalClass;
 
 import java.util.List;
 
+import static io.trino.spi.experimental.ExperimentalClass.STATIC_MEMBER;
+
 @SuppressWarnings("unused")
 public class TrinoExperimentalSpiPositiveCases
 {
@@ -50,6 +52,18 @@ public class TrinoExperimentalSpiPositiveCases
     public ExperimentalClass asReturnType()
     {
         return null;
+    }
+
+    public void referencingStaticMember()
+    {
+        // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+        String ignore = ExperimentalClass.STATIC_MEMBER;
+    }
+
+    public void referencingStaticMemberAsStaticImport()
+    {
+        // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+        String ignore = STATIC_MEMBER;
     }
 
     public static class AsBaseClass

--- a/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiPositiveCases.java
+++ b/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiPositiveCases.java
@@ -12,6 +12,8 @@ package io.starburst.errorprone.testdata;
 
 import io.trino.spi.experimental.ClassWithExperimentalMember;
 import io.trino.spi.experimental.ExperimentalClass;
+import io.trino.spi.experimental.ExperimentalEnum;
+import io.trino.spi.experimental.ExperimentalRecord;
 
 import java.util.List;
 
@@ -24,7 +26,16 @@ public class TrinoExperimentalSpiPositiveCases
     private final Object instantiation = new ExperimentalClass();
 
     // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+    private final Object instantiationRecord = new ExperimentalRecord("foo");
+
+    // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
     private ExperimentalClass asField;
+
+    // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+    private ExperimentalEnum asEnumField;
+
+    // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+    private ExperimentalRecord asRecordField;
 
     private final ClassWithExperimentalMember classWithMember = new ClassWithExperimentalMember();
 
@@ -33,13 +44,35 @@ public class TrinoExperimentalSpiPositiveCases
     {}
 
     // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+    public void asParameter(ExperimentalEnum param)
+    {}
+
+    // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+    public void asParameter(ExperimentalRecord param)
+    {}
+
+    // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
     public void asTypeArgument(List<ExperimentalClass> param)
+    {}
+
+    // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+    public void asTypeArgumentEnum(List<ExperimentalEnum> param)
+    {}
+
+    // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+    public void asTypeArgumentRecord(List<ExperimentalRecord> param)
     {}
 
     public void asLocalVariable()
     {
         // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
         ExperimentalClass var;
+
+        // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+        ExperimentalEnum varEnum;
+
+        // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+        ExperimentalRecord varRecord;
     }
 
     public void methodCall()
@@ -50,6 +83,18 @@ public class TrinoExperimentalSpiPositiveCases
 
     // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
     public ExperimentalClass asReturnType()
+    {
+        return null;
+    }
+
+    // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+    public ExperimentalEnum asReturnTypeEnum()
+    {
+        return null;
+    }
+
+    // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.
+    public ExperimentalRecord asReturnTypeRecord()
     {
         return null;
     }

--- a/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiPositiveCases.java
+++ b/src/test/java/io/starburst/errorprone/testdata/TrinoExperimentalSpiPositiveCases.java
@@ -15,6 +15,7 @@ import io.trino.spi.experimental.ExperimentalClass;
 
 import java.util.List;
 
+@SuppressWarnings("unused")
 public class TrinoExperimentalSpiPositiveCases
 {
     // BUG: Diagnostic contains: Do not use Trino @Experimental SPIs.

--- a/src/test/java/io/trino/spi/Experimental.java
+++ b/src/test/java/io/trino/spi/Experimental.java
@@ -19,6 +19,10 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+/**
+ * A stand-in for the actual annotation in Trino SPI; we can't use the original
+ * because it would introduce dependency cycles.
+ */
 @Retention(RUNTIME)
 @Target({TYPE, FIELD, METHOD, CONSTRUCTOR})
 public @interface Experimental

--- a/src/test/java/io/trino/spi/deprecated/ClassWithDeprecatedMember.java
+++ b/src/test/java/io/trino/spi/deprecated/ClassWithDeprecatedMember.java
@@ -10,6 +10,7 @@
 
 package io.trino.spi.deprecated;
 
+@SuppressWarnings("DeprecatedIsStillUsed")
 public class ClassWithDeprecatedMember
 {
     @Deprecated

--- a/src/test/java/io/trino/spi/deprecated/DeprecatedClass.java
+++ b/src/test/java/io/trino/spi/deprecated/DeprecatedClass.java
@@ -10,6 +10,7 @@
 
 package io.trino.spi.deprecated;
 
+@SuppressWarnings({"DeprecatedIsStillUsed", "unused"})
 @Deprecated
 public class DeprecatedClass
 {

--- a/src/test/java/io/trino/spi/deprecated/DeprecatedClass.java
+++ b/src/test/java/io/trino/spi/deprecated/DeprecatedClass.java
@@ -14,6 +14,8 @@ package io.trino.spi.deprecated;
 @Deprecated
 public class DeprecatedClass
 {
+    public static final String STATIC_MEMBER = "dummy";
+
     public void foo()
     {}
 }

--- a/src/test/java/io/trino/spi/deprecated/DeprecatedEnum.java
+++ b/src/test/java/io/trino/spi/deprecated/DeprecatedEnum.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package io.trino.spi.deprecated;
+
+@SuppressWarnings({"DeprecatedIsStillUsed", "unused"})
+@Deprecated
+public enum DeprecatedEnum
+{
+    FOO,
+}

--- a/src/test/java/io/trino/spi/deprecated/DeprecatedRecord.java
+++ b/src/test/java/io/trino/spi/deprecated/DeprecatedRecord.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package io.trino.spi.deprecated;
+
+@SuppressWarnings({"DeprecatedIsStillUsed", "unused"})
+@Deprecated
+public record DeprecatedRecord(String foo)
+{
+}

--- a/src/test/java/io/trino/spi/deprecated/NotDeprecatedClass.java
+++ b/src/test/java/io/trino/spi/deprecated/NotDeprecatedClass.java
@@ -10,6 +10,7 @@
 
 package io.trino.spi.deprecated;
 
+@SuppressWarnings("unused")
 public class NotDeprecatedClass
 {
     public void foo()

--- a/src/test/java/io/trino/spi/deprecated/NotDeprecatedClass.java
+++ b/src/test/java/io/trino/spi/deprecated/NotDeprecatedClass.java
@@ -13,6 +13,8 @@ package io.trino.spi.deprecated;
 @SuppressWarnings("unused")
 public class NotDeprecatedClass
 {
+    public static final String STATIC_MEMBER = "dummy";
+
     public void foo()
     {}
 }

--- a/src/test/java/io/trino/spi/experimental/ExperimentalClass.java
+++ b/src/test/java/io/trino/spi/experimental/ExperimentalClass.java
@@ -12,6 +12,7 @@ package io.trino.spi.experimental;
 
 import io.trino.spi.Experimental;
 
+@SuppressWarnings("unused")
 @Experimental
 public class ExperimentalClass
 {

--- a/src/test/java/io/trino/spi/experimental/ExperimentalClass.java
+++ b/src/test/java/io/trino/spi/experimental/ExperimentalClass.java
@@ -16,6 +16,8 @@ import io.trino.spi.Experimental;
 @Experimental
 public class ExperimentalClass
 {
+    public static final String STATIC_MEMBER = "dummy";
+
     public void foo()
     {}
 }

--- a/src/test/java/io/trino/spi/experimental/ExperimentalEnum.java
+++ b/src/test/java/io/trino/spi/experimental/ExperimentalEnum.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package io.trino.spi.experimental;
+
+import io.trino.spi.Experimental;
+
+@SuppressWarnings("unused")
+@Experimental
+public enum ExperimentalEnum
+{
+    FOO,
+}

--- a/src/test/java/io/trino/spi/experimental/ExperimentalRecord.java
+++ b/src/test/java/io/trino/spi/experimental/ExperimentalRecord.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+
+package io.trino.spi.experimental;
+
+import io.trino.spi.Experimental;
+
+@SuppressWarnings("unused")
+@Experimental
+public record ExperimentalRecord(String foo)
+{
+}

--- a/src/test/java/io/trino/spi/experimental/NotExperimentalClass.java
+++ b/src/test/java/io/trino/spi/experimental/NotExperimentalClass.java
@@ -13,6 +13,8 @@ package io.trino.spi.experimental;
 @SuppressWarnings("unused")
 public class NotExperimentalClass
 {
+    public static final String STATIC_MEMBER = "dummy";
+
     public void foo()
     {}
 }

--- a/src/test/java/io/trino/spi/experimental/NotExperimentalClass.java
+++ b/src/test/java/io/trino/spi/experimental/NotExperimentalClass.java
@@ -10,6 +10,7 @@
 
 package io.trino.spi.experimental;
 
+@SuppressWarnings("unused")
 public class NotExperimentalClass
 {
     public void foo()

--- a/src/test/java/io/trino/spi/ignored/IgnoredDeprecatedClass.java
+++ b/src/test/java/io/trino/spi/ignored/IgnoredDeprecatedClass.java
@@ -10,6 +10,7 @@
 
 package io.trino.spi.ignored;
 
+@SuppressWarnings("unused")
 @Deprecated
 public class IgnoredDeprecatedClass
 {

--- a/src/test/java/io/trino/spi/ignored/IgnoredExperimentalClass.java
+++ b/src/test/java/io/trino/spi/ignored/IgnoredExperimentalClass.java
@@ -12,6 +12,7 @@ package io.trino.spi.ignored;
 
 import io.trino.spi.Experimental;
 
+@SuppressWarnings("unused")
 @Experimental
 public class IgnoredExperimentalClass
 {


### PR DESCRIPTION
The case was an annotated member (e.g. a method), but which was in an explicitly ignored class. That member was incorrectly reported as annotated. The fix is to check if the member's parent (owner) is an ignored class whenever we determine that the member is annotated.

The tests are changed to run against a version of the full set of scenarios instead of hand-picked synthetic cases.

Also includes some tweaks to tests to make the coverage better and sync them between the two annotation checkers.