### PR TITLE
Upgrade Error Prone to 2.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,9 @@
         <project.build.targetJdk>17</project.build.targetJdk>
 
         <dep.auto-service.version>1.0.1</dep.auto-service.version>
-        <dep.error-prone.version>2.19.1</dep.error-prone.version>
+        <dep.error-prone.version>2.23.0</dep.error-prone.version>
         <dep.compile-testing.version>0.19</dep.compile-testing.version>
+        <dep.guava.version>32.1.1-jre</dep.guava.version>
 
         <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
 

--- a/src/main/java/io/starburst/errorprone/DeprecatedApiChecker.java
+++ b/src/main/java/io/starburst/errorprone/DeprecatedApiChecker.java
@@ -17,8 +17,6 @@ import com.google.errorprone.bugpatterns.BugChecker;
 
 import javax.inject.Inject;
 
-import java.util.Collections;
-
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "DeprecatedApi",
@@ -41,9 +39,9 @@ public final class DeprecatedApiChecker
     {
         super(
                 "java.lang.Deprecated",
-                flags.getSet("DeprecatedApi:BasePackages").orElse(Collections.emptySet()),
-                flags.getSet("DeprecatedApi:IgnoredPackages").orElse(Collections.emptySet()),
-                flags.getSet("DeprecatedApi:IgnoredTypes").orElse(Collections.emptySet()));
+                flags.getSetOrEmpty("DeprecatedApi:BasePackages"),
+                flags.getSetOrEmpty("DeprecatedApi:IgnoredPackages"),
+                flags.getSetOrEmpty("DeprecatedApi:IgnoredTypes"));
     }
 
     @Override

--- a/src/main/java/io/starburst/errorprone/TrinoExperimentalSpiChecker.java
+++ b/src/main/java/io/starburst/errorprone/TrinoExperimentalSpiChecker.java
@@ -17,8 +17,6 @@ import com.google.errorprone.bugpatterns.BugChecker;
 
 import javax.inject.Inject;
 
-import java.util.Collections;
-
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "TrinoExperimentalSpi",
@@ -41,9 +39,9 @@ public final class TrinoExperimentalSpiChecker
     {
         super(
                 "io.trino.spi.Experimental",
-                flags.getSet("TrinoExperimentalSpi:BasePackages").orElse(Collections.emptySet()),
-                flags.getSet("TrinoExperimentalSpi:IgnoredPackages").orElse(Collections.emptySet()),
-                flags.getSet("TrinoExperimentalSpi:IgnoredTypes").orElse(Collections.emptySet()));
+                flags.getSetOrEmpty("TrinoExperimentalSpi:BasePackages"),
+                flags.getSetOrEmpty("TrinoExperimentalSpi:IgnoredPackages"),
+                flags.getSetOrEmpty("TrinoExperimentalSpi:IgnoredTypes"));
     }
 
     @Override


### PR DESCRIPTION
There is an API change, so this is needed if we want to upgrade any of the dependent projects to the new Error Prone.